### PR TITLE
Rename to eslint-plugin

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,9 +1,9 @@
 ESLint plugin containing hapi style guide rules and config. To use in your project, add
-[`@hapi/eslint-plugin-hapi`](https://github.com/hapijs/eslint-plugin-hapi) to your `package.json`, then in your ESLint configuration add:
+[`@hapi/eslint-plugin`](https://github.com/hapijs/eslint-plugin-hapi) to your `package.json`, then in your ESLint configuration add:
 
 ```json
 {
-  "extends": "plugin:@hapi/hapi/recommended"
+  "extends": "plugin:@hapi/recommended"
 }
 ```
 
@@ -78,11 +78,11 @@ This rule does not accept any configuration options.
 
 | Rule | Option |
 |------|--------|
-| **'@hapi/hapi/capitalize-modules'** | ['warn', 'global-scope-only'] |
-| **'@hapi/hapi/for-loop'** | ['warn', { maxDepth: 3, startIterator: 'i' }] |
-| **'@hapi/hapi/no-var'** | 'error' |
-| **'@hapi/hapi/scope-start'** | 'warn' |
-| **'@hapi/hapi/no-arrowception'** | 'error' |
+| **'@hapi/capitalize-modules'** | ['warn', 'global-scope-only'] |
+| **'@hapi/for-loop'** | ['warn', { maxDepth: 3, startIterator: 'i' }] |
+| **'@hapi/no-var'** | 'error' |
+| **'@hapi/scope-start'** | 'warn' |
+| **'@hapi/no-arrowception'** | 'error' |
 | **'camelcase'** | 'off' |
 | **'consistent-return'** | 'off' |
 | **'vars-on-top'** | 'off' |

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 ESLint plugin containing hapi style guide rules and config. To use in your project, add
-[`@hapi/eslint-plugin`](https://github.com/hapijs/eslint-plugin-hapi) to your `package.json`, then in your ESLint configuration add:
+[`@hapi/eslint-plugin`](https://github.com/hapijs/eslint-plugin) to your `package.json`, then in your ESLint configuration add:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <a href="https://hapi.dev"><img src="https://raw.githubusercontent.com/hapijs/assets/master/images/family.png" width="180px" align="right" /></a>
 
-# @hapi/eslint-plugin-hapi
+# @hapi/eslint-plugin
 
 #### ESLint plugin containing hapi style guide rules and config.
 
-**eslint-plugin-hapi** is part of the **hapi** ecosystem and was designed to work seamlessly with the [hapi web framework](https://hapi.dev) and its other components (but works great on its own or with other frameworks). If you are using a different web framework and find this module useful, check out [hapi](https://hapi.dev) – they work even better together.
+**eslint-plugin** is part of the **hapi** ecosystem and was designed to work seamlessly with the [hapi web framework](https://hapi.dev) and its other components (but works great on its own or with other frameworks). If you are using a different web framework and find this module useful, check out [hapi](https://hapi.dev) – they work even better together.
 
 ### Visit the [hapi.dev](https://hapi.dev) Developer Portal for tutorials, documentation, and support
 
 ## Useful resources
 
-- [Documentation and API](https://hapi.dev/family/eslint-plugin-hapi/)
-- [Version status](https://hapi.dev/resources/status/#eslint-plugin-hapi) (builds, dependencies, node versions, licenses, eol)
-- [Changelog](https://hapi.dev/family/eslint-plugin-hapi/changelog/)
+- [Documentation and API](https://hapi.dev/family/eslint-plugin/)
+- [Version status](https://hapi.dev/resources/status/#eslint-plugin) (builds, dependencies, node versions, licenses, eol)
+- [Changelog](https://hapi.dev/family/eslint-plugin/changelog/)
 - [Project policies](https://hapi.dev/policies/)
 - [Free and commercial support options](https://hapi.dev/support/)

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    plugins: ['@hapi/hapi'],
+    plugins: ['@hapi'],
     env: {
         node: true,
         es2020: true
@@ -10,11 +10,11 @@ module.exports = {
         ecmaVersion: 2020
     },
     rules: {
-        '@hapi/hapi/capitalize-modules': ['warn', 'global-scope-only'],
-        '@hapi/hapi/for-loop': ['warn', { maxDepth: 3, startIterator: 'i' }],
-        '@hapi/hapi/no-var': 'error',
-        '@hapi/hapi/scope-start': 'warn',
-        '@hapi/hapi/no-arrowception': 'error',
+        '@hapi/capitalize-modules': ['warn', 'global-scope-only'],
+        '@hapi/for-loop': ['warn', { maxDepth: 3, startIterator: 'i' }],
+        '@hapi/no-var': 'error',
+        '@hapi/scope-start': 'warn',
+        '@hapi/no-arrowception': 'error',
         'camelcase': 'off',
         'consistent-return': 'off',
         'vars-on-top': 'off',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.3.5",
   "description": "ESLint plugin containing hapi style guide rules and config",
   "main": "lib/index.js",
-  "repository": "https://github.com/hapijs/eslint-plugin-hapi.git",
+  "repository": "https://github.com/hapijs/eslint-plugin.git",
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hapi/eslint-plugin-hapi",
+  "name": "@hapi/eslint-plugin",
   "version": "4.3.5",
   "description": "ESLint plugin containing hapi style guide rules and config",
   "main": "lib/index.js",
@@ -17,7 +17,7 @@
   "dependencies": {},
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin-hapi": "file:.",
+    "@hapi/eslint-plugin": "file:.",
     "@hapi/lab": "^23.0.0",
     "eslint": "^7.5.0"
   },

--- a/test/configs/recommended.js
+++ b/test/configs/recommended.js
@@ -22,7 +22,7 @@ internals.lintFile = function (file) {
 
     const cli = new ESLint.CLIEngine({
         useEslintrc: false,
-        baseConfig: { extends: 'plugin:@hapi/hapi/recommended' }
+        baseConfig: { extends: 'plugin:@hapi/recommended' }
     });
 
     const data = Fs.readFileSync(Path.join(__dirname, file), 'utf8');
@@ -217,7 +217,7 @@ describe('recommended config', () => {
         expect(msg.nodeType).to.equal('FunctionExpression');
     });
 
-    it('enforces @hapi/hapi/for-loop', () => {
+    it('enforces @hapi/for-loop', () => {
 
         const output = internals.lintFile('fixtures/hapi-for-you.js');
         const results = output.results[0];
@@ -229,7 +229,7 @@ describe('recommended config', () => {
 
         let msg = results.messages[0];
 
-        expect(msg.ruleId).to.equal('@hapi/hapi/for-loop');
+        expect(msg.ruleId).to.equal('@hapi/for-loop');
         expect(msg.severity).to.equal(1);
         expect(msg.message).to.equal('Expected iterator \'j\', but got \'k\'.');
         expect(msg.line).to.equal(7);
@@ -238,7 +238,7 @@ describe('recommended config', () => {
 
         msg = results.messages[1];
 
-        expect(msg.ruleId).to.equal('@hapi/hapi/for-loop');
+        expect(msg.ruleId).to.equal('@hapi/for-loop');
         expect(msg.severity).to.equal(1);
         expect(msg.message).to.equal('Update to iterator should use prefix operator.');
         expect(msg.line).to.equal(7);
@@ -246,7 +246,7 @@ describe('recommended config', () => {
         expect(msg.nodeType).to.equal('ForStatement');
     });
 
-    it('enforces @hapi/hapi/scope-start', () => {
+    it('enforces @hapi/scope-start', () => {
 
         const output = internals.lintFile('fixtures/hapi-scope-start.js');
         const results = output.results[0];
@@ -258,7 +258,7 @@ describe('recommended config', () => {
 
         const msg = results.messages[0];
 
-        expect(msg.ruleId).to.equal('@hapi/hapi/scope-start');
+        expect(msg.ruleId).to.equal('@hapi/scope-start');
         expect(msg.severity).to.equal(1);
         expect(msg.message).to.equal('Missing blank line at beginning of function.');
         expect(msg.line).to.equal(2);
@@ -266,7 +266,7 @@ describe('recommended config', () => {
         expect(msg.nodeType).to.equal('FunctionExpression');
     });
 
-    it('enforces @hapi/hapi/capitalize-modules', () => {
+    it('enforces @hapi/capitalize-modules', () => {
 
         const output = internals.lintFile('fixtures/hapi-capitalize-modules.js');
         const results = output.results[0];
@@ -278,7 +278,7 @@ describe('recommended config', () => {
 
         const msg = results.messages[0];
 
-        expect(msg.ruleId).to.equal('@hapi/hapi/capitalize-modules');
+        expect(msg.ruleId).to.equal('@hapi/capitalize-modules');
         expect(msg.severity).to.equal(1);
         expect(msg.message).to.equal('Imported module variable name not capitalized.');
         expect(msg.line).to.equal(5);
@@ -286,7 +286,7 @@ describe('recommended config', () => {
         expect(msg.nodeType).to.equal('VariableDeclarator');
     });
 
-    it('enforces @hapi/hapi/no-arrowception', () => {
+    it('enforces @hapi/no-arrowception', () => {
 
         const output = internals.lintFile('fixtures/no-arrowception.js');
         const results = output.results[0];
@@ -298,7 +298,7 @@ describe('recommended config', () => {
 
         const msg = results.messages[0];
 
-        expect(msg.ruleId).to.equal('@hapi/hapi/no-arrowception');
+        expect(msg.ruleId).to.equal('@hapi/no-arrowception');
         expect(msg.severity).to.equal(2);
         expect(msg.message).to.equal('Arrow function implicitly creates arrow function.');
         expect(msg.line).to.equal(2);
@@ -406,7 +406,7 @@ describe('recommended config', () => {
         expect(msg.nodeType).to.equal('Identifier');
     });
 
-    it('enforces hapi/hapi-no-var', () => {
+    it('enforces @hapi/no-var', () => {
 
         const output = internals.lintFile('fixtures/no-var.js');
         const results = output.results[0];
@@ -418,7 +418,7 @@ describe('recommended config', () => {
 
         const msg = results.messages[0];
 
-        expect(msg.ruleId).to.equal('@hapi/hapi/no-var');
+        expect(msg.ruleId).to.equal('@hapi/no-var');
         expect(msg.severity).to.equal(2);
         expect(msg.message).to.equal('Unexpected var, use let or const instead.');
         expect(msg.line).to.equal(4);


### PR DESCRIPTION
Handles the in-repo part of #21.

Once merged, the following still needs to be done:

1. Rename this github repository.
1. Create and publish the package. Maybe as v5.0 for good measure?
1. Update lab https://github.com/hapijs/lab/pull/990.
1. Update [hapi.dev](https://github.com/hapijs/hapi.dev/blob/a3b805bb3386d3b55fe26957423a1aa65ca574b8/assets/js/getModuleInfo.js#L31).
1. Eventually, update local lab dependency with v24 release.

Fortunately, no hapi project have any `eslint-disable` lines containing `@hapi/hapi` rules, so it should provide a clean update.